### PR TITLE
Add PhotoPrism local setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # PhotoViewer
 App to load photos and view on the web
+
+## Running PhotoPrism Locally
+
+Use the `install_photoprism.sh` script in the `scripts` folder to install dependencies and launch PhotoPrism without Docker. The script clones the official source from GitHub, installs required packages (Go, Node.js, Yarn, MariaDB and ffmpeg) using `apt` on Debian/Ubuntu or `pacman` on Arch, sets up a basic `.env` file and starts the server on `http://localhost:2342`.
+
+```
+PHOTOS_PATH=~/Pictures ./scripts/install_photoprism.sh
+```
+
+Once the server is running you can index your photos:
+
+```
+./photoprism index
+```
+

--- a/scripts/install_photoprism.sh
+++ b/scripts/install_photoprism.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Install and run PhotoPrism from source without Docker.
+# Works on Ubuntu/Debian or Arch systems.
+
+set -e
+
+# Location of photo originals
+PHOTOS_PATH="${PHOTOS_PATH:-$HOME/Pictures}"
+
+# Install dependencies using apt (Debian/Ubuntu) or pacman (Arch)
+if command -v apt >/dev/null 2>&1; then
+    sudo apt update
+    sudo apt install -y git golang-go nodejs npm mariadb-server ffmpeg
+    if ! command -v yarn >/dev/null 2>&1; then
+        sudo npm install -g yarn
+    fi
+elif command -v pacman >/dev/null 2>&1; then
+    sudo pacman -Syu --needed git go nodejs npm mariadb ffmpeg yarn
+else
+    echo "Unsupported package manager. Install Go, Node.js, Yarn, and MariaDB manually." >&2
+    exit 1
+fi
+
+if [ ! -d photoprism ]; then
+    git clone https://github.com/photoprism/photoprism.git
+fi
+cd photoprism
+
+cp -n .env.example .env
+sed -i "s|PHOTOPRISM_ORIGINALS_PATH=.*|PHOTOPRISM_ORIGINALS_PATH=\"$PHOTOS_PATH\"|" .env
+sed -i "s|PHOTOPRISM_ADMIN_PASSWORD=.*|PHOTOPRISM_ADMIN_PASSWORD=\"insecure\"|" .env
+sed -i "s|PHOTOPRISM_HTTP_PORT=.*|PHOTOPRISM_HTTP_PORT=2342|" .env
+
+# Build frontend
+yarn install
+yarn build
+
+# Run PhotoPrism
+
+go run ./cmd/photoprism start
+# After the server starts, index photos with:
+#   ./photoprism index


### PR DESCRIPTION
## Summary
- add `install_photoprism.sh` helper script
- document how to run PhotoPrism without Docker in README
- update script to support Arch Linux via pacman

## Testing
- `bash -n scripts/install_photoprism.sh`


------
https://chatgpt.com/codex/tasks/task_e_687d2d792660832b9aca2bb140fb2df5